### PR TITLE
Use Fileprovider to serve attachments to email applications

### DIFF
--- a/bugshaker/build.gradle
+++ b/bugshaker/build.gradle
@@ -20,7 +20,7 @@ repositories {
 // Shared project metadata
 
 ext {
-    bugShakerVersion = "0.5.1-local"
+    bugShakerVersion = "0.5.2-local"
     bugShakerWebsiteUrl = 'https://github.com/stkent/bugshaker-android'
     bugShakerVcsUrl = 'https://github.com/stkent/bugshaker-android.git'
     bugShakerGroupId = 'com.github.stkent'
@@ -64,9 +64,11 @@ android {
 
 dependencies {
     javadocDeps 'com.android.support:support-annotations:23.1.1'
+    javadocDeps 'com.android.support:support-v4:23.1.1'
     javadocDeps 'com.squareup:seismic:1.0.2'
 
     compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
     compile 'com.squareup:seismic:1.0.2'
 }
 

--- a/bugshaker/src/main/AndroidManifest.xml
+++ b/bugshaker/src/main/AndroidManifest.xml
@@ -1,8 +1,16 @@
 <manifest package="com.github.stkent.bugshaker"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
-    <application />
+    <application>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.github.stkent.bugshaker.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+    </application>
 
 </manifest>

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/BugShaker.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/BugShaker.java
@@ -22,6 +22,8 @@ import android.app.Application;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.hardware.SensorManager;
 import android.net.Uri;
 import android.support.annotation.NonNull;
@@ -31,6 +33,7 @@ import android.widget.Toast;
 import com.squareup.seismic.ShakeDetector;
 
 import java.io.IOException;
+import java.util.List;
 
 import static android.content.Context.SENSOR_SERVICE;
 
@@ -201,6 +204,17 @@ public final class BugShaker implements ShakeDetector.Listener {
 
         final Intent feedbackEmailIntent = feedbackEmailIntentProvider
                 .getFeedbackEmailIntent(emailAddresses, emailSubjectLine, screenshotUri);
+
+        final List<ResolveInfo> resolveInfoList = applicationContext.getPackageManager()
+                .queryIntentActivities(feedbackEmailIntent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        for (final ResolveInfo receivingApplicationInfo: resolveInfoList) {
+            // FIXME: revoke these permissions at some point!
+            applicationContext.grantUriPermission(
+                    receivingApplicationInfo.activityInfo.packageName,
+                    (Uri) feedbackEmailIntent.getParcelableExtra(Intent.EXTRA_STREAM),
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        }
 
         activity.startActivity(feedbackEmailIntent);
 

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
@@ -67,6 +67,7 @@ public final class FeedbackEmailIntentProvider {
 
         if (screenshotUri != null) {
             emailIntent.putExtra(Intent.EXTRA_STREAM, screenshotUri);
+            emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         return emailIntent;

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
@@ -62,7 +62,6 @@ public final class FeedbackEmailIntentProvider {
         final Intent emailIntent = getBaseFeedbackEmailIntent(emailAddresses, emailSubjectLine);
 
         emailIntent.putExtra(Intent.EXTRA_STREAM, screenshotUri);
-        emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
         return emailIntent;
     }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
@@ -23,7 +23,6 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -51,26 +50,32 @@ public final class FeedbackEmailIntentProvider {
             @NonNull final String[] emailAddresses,
             @NonNull final String emailSubjectLine) {
 
-        return getFeedbackEmailIntent(emailAddresses, emailSubjectLine, null);
+        return getBaseFeedbackEmailIntent(emailAddresses, emailSubjectLine);
     }
 
     @NonNull
     public Intent getFeedbackEmailIntent(
             @NonNull final String[] emailAddresses,
             @NonNull final String emailSubjectLine,
-            @Nullable final Uri screenshotUri) {
+            @NonNull final Uri screenshotUri) {
+
+        final Intent emailIntent = getBaseFeedbackEmailIntent(emailAddresses, emailSubjectLine);
+
+        emailIntent.putExtra(Intent.EXTRA_STREAM, screenshotUri);
+        emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        return emailIntent;
+    }
+
+    @NonNull
+    private Intent getBaseFeedbackEmailIntent(
+            @NonNull final String[] emailAddresses,
+            @NonNull final String emailSubjectLine) {
 
         final String appInfo = getApplicationInfoString();
 
-        final Intent emailIntent = genericEmailIntentProvider
+        return genericEmailIntentProvider
                 .getBasicEmailIntent(emailAddresses, emailSubjectLine, appInfo);
-
-        if (screenshotUri != null) {
-            emailIntent.putExtra(Intent.EXTRA_STREAM, screenshotUri);
-            emailIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        }
-
-        return emailIntent;
     }
 
     @NonNull

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/Logger.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/Logger.java
@@ -41,4 +41,10 @@ public final class Logger {
         }
     }
 
+    public void printStackTrace(@NonNull final Exception exception) {
+        if (loggingEnabled) {
+            exception.printStackTrace();
+        }
+    }
+
 }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.bugshaker;
 
 import android.app.Activity;

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
@@ -72,6 +72,9 @@ public final class ScreenshotProvider {
         final File screenshotsDir = new File(
                 applicationContext.getFilesDir(), SCREENSHOTS_DIRECTORY_NAME);
 
+        //noinspection ResultOfMethodCallIgnored
+        screenshotsDir.mkdirs();
+
         return new File(screenshotsDir, SCREENSHOT_FILE_NAME);
     }
 

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
@@ -1,44 +1,61 @@
 package com.github.stkent.bugshaker;
 
 import android.app.Activity;
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.net.Uri;
-import android.os.Environment;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import android.support.v4.content.FileProvider;
 import android.view.View;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 
 public final class ScreenshotProvider {
 
+    private static final String AUTHORITY = "com.github.stkent.bugshaker.fileprovider";
+    private static final String SCREENSHOTS_DIRECTORY_NAME = "screenshots";
+    private static final String SCREENSHOT_FILE_NAME = "screenshot.jpg";
+
+    @NonNull
+    private final Context applicationContext;
+
     @NonNull
     private final Logger logger;
 
-    public ScreenshotProvider(@NonNull final Logger logger) {
+    public ScreenshotProvider(
+            @NonNull final Context applicationContext,
+            @NonNull final Logger logger) {
+
+        this.applicationContext = applicationContext;
         this.logger = logger;
     }
 
-    @Nullable
-    public Uri getScreenshotUri(@NonNull final Activity activity) {
-        final File screenshotFile = new File(getScreenshotFilePath());
+    @NonNull
+    public Uri getScreenshotUri(@NonNull final Activity activity) throws IOException {
+        final File screenshotFile = getScreenshotFile();
         final Bitmap screenshotBitmap = getBitmapFromRootView(activity);
 
-        try {
-            final OutputStream fileOutputStream = new FileOutputStream(screenshotFile);
-            screenshotBitmap.compress(Bitmap.CompressFormat.JPEG, 90, fileOutputStream);
-            fileOutputStream.flush();
-            fileOutputStream.close();
-            return Uri.fromFile(screenshotFile);
-        } catch (final Exception exception) {
-            logger.e(exception.getMessage());
+        final OutputStream fileOutputStream = new FileOutputStream(screenshotFile);
+        screenshotBitmap.compress(Bitmap.CompressFormat.JPEG, 90, fileOutputStream);
+        fileOutputStream.flush();
+        fileOutputStream.close();
 
-            return null;
-        }
+        logger.d("Screenshot successfully saved to file: " + screenshotFile.getAbsolutePath());
+
+        final Uri result = FileProvider.getUriForFile(
+                applicationContext,
+                AUTHORITY,
+                screenshotFile);
+
+        logger.d("URI for screenshot file successfully created: " + result);
+
+        return result;
     }
+
     private Bitmap getBitmapFromRootView(@NonNull final Activity activity) {
         final View view = activity.getWindow().getDecorView().getRootView();
 
@@ -51,9 +68,11 @@ public final class ScreenshotProvider {
         return screenshotBitmap;
     }
 
-    private String getScreenshotFilePath() {
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
-                + File.separator + "BugShaker-Screenshot.jpg";
+    private File getScreenshotFile() {
+        final File screenshotsDir = new File(
+                applicationContext.getFilesDir(), SCREENSHOTS_DIRECTORY_NAME);
+
+        return new File(screenshotsDir, SCREENSHOT_FILE_NAME);
     }
 
 }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
@@ -17,8 +17,8 @@ import java.io.OutputStream;
 public final class ScreenshotProvider {
 
     private static final String AUTHORITY = "com.github.stkent.bugshaker.fileprovider";
-    private static final String SCREENSHOTS_DIRECTORY_NAME = "screenshots";
-    private static final String SCREENSHOT_FILE_NAME = "screenshot.jpg";
+    private static final String SCREENSHOTS_DIRECTORY_NAME = "bug-reports";
+    private static final String SCREENSHOT_FILE_NAME = "latest-screenshot.jpg";
 
     @NonNull
     private final Context applicationContext;

--- a/bugshaker/src/main/res/xml/filepaths.xml
+++ b/bugshaker/src/main/res/xml/filepaths.xml
@@ -1,3 +1,21 @@
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 <paths>
     <files-path path="bug-reports/" name="bug-reports" />
 </paths>

--- a/bugshaker/src/main/res/xml/filepaths.xml
+++ b/bugshaker/src/main/res/xml/filepaths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <files-path path="screenshots/" name="bugshaker-screenshots" />
+</paths>

--- a/bugshaker/src/main/res/xml/filepaths.xml
+++ b/bugshaker/src/main/res/xml/filepaths.xml
@@ -1,3 +1,3 @@
 <paths>
-    <files-path path="screenshots/" name="bugshaker-screenshots" />
+    <files-path path="bug-reports/" name="bug-reports" />
 </paths>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.github.stkent:bugshaker:0.5.1-local'
+    compile 'com.github.stkent:bugshaker:0.5.2-local'
 }


### PR DESCRIPTION
This works around apps that [don't handle revoked permissions gracefully](http://stackoverflow.com/questions/32318692/android-attaching-a-file-to-gmail-cant-attach-empty-file).
