### PR TITLE
Add license header to all example app files

### DIFF
--- a/bugshaker/build.gradle
+++ b/bugshaker/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
     repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        jcenter()
     }
 
     dependencies {
@@ -10,7 +8,6 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath 'com.noveogroup.android:check:1.2.3'
         classpath 'com.btkelly:gnag:0.1.0'
-        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
     }
 }
 
@@ -19,7 +16,6 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.noveogroup.android.check'
 apply plugin: 'gnag-plugin'
-apply plugin: 'com.github.hierynomus.license'
 
 // Shared project metadata
 
@@ -30,11 +26,6 @@ ext {
     bugShakerGroupId = 'com.github.stkent'
     bugShakerArtifactId = 'bugshaker'
     bugShakerDescription = "Send Android bug reports via email. Shake to summon!"
-}
-
-license {
-    header = file('../Apache2License.txt')
-    strictCheck true
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,28 @@
 buildscript {
     repositories {
         jcenter()
+
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+    }
+
+    apply plugin: 'com.github.hierynomus.license'
+
+    license {
+        header = file("${rootProject.projectDir}/Apache2License.txt")
+        strictCheck true
     }
 }
 

--- a/example/src/main/java/com/example/bugshaker/BaseActivity.java
+++ b/example/src/main/java/com/example/bugshaker/BaseActivity.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.example.bugshaker;
 
 import android.content.Intent;

--- a/example/src/main/java/com/example/bugshaker/CustomApplication.java
+++ b/example/src/main/java/com/example/bugshaker/CustomApplication.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.example.bugshaker;
 
 import android.app.Application;

--- a/example/src/main/java/com/example/bugshaker/SecuredActivity.java
+++ b/example/src/main/java/com/example/bugshaker/SecuredActivity.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.example.bugshaker;
 
 import android.os.Bundle;

--- a/example/src/main/java/com/example/bugshaker/UnsecuredActivity.java
+++ b/example/src/main/java/com/example/bugshaker/UnsecuredActivity.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.example.bugshaker;
 
 import android.os.Bundle;

--- a/example/src/main/res/layout/activity_secured.xml
+++ b/example/src/main/res/layout/activity_secured.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"

--- a/example/src/main/res/layout/activity_unsecured.xml
+++ b/example/src/main/res/layout/activity_unsecured.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"

--- a/example/src/main/res/menu/menu_main.xml
+++ b/example/src/main/res/menu/menu_main.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 <menu
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/example/src/main/res/values/colors.xml
+++ b/example/src/main/res/values/colors.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 
 <resources>
 

--- a/example/src/main/res/values/dimens.xml
+++ b/example/src/main/res/values/dimens.xml
@@ -1,3 +1,21 @@
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 <resources>
 
     <dimen name="activity_padding">16dp</dimen>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -1,3 +1,21 @@
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 <resources>
 
     <string name="app_name">BugShaker</string>

--- a/example/src/main/res/values/styles.xml
+++ b/example/src/main/res/values/styles.xml
@@ -1,3 +1,21 @@
+<!--
+
+    Copyright 2016 Stuart Kent
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+-->
 <resources>
 
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">


### PR DESCRIPTION
Closes #15 
## Explanation

Initial root `build.gradle`:

``` groovy
buildscript {
    repositories {
        jcenter()
    }

    dependencies {
        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
    }
}

allprojects {
    repositories {
        jcenter()
    }
}

// ...
```

Initial bugshaker `build.gradle`:

``` groovy
buildscript {
    repositories {
        maven {
            url "https://plugins.gradle.org/m2/"
        }
    }

    dependencies {
        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
        // ...
        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
    }
}

apply plugin: 'com.android.library'
apply plugin: 'com.jfrog.bintray'
// ...
apply plugin: 'com.github.hierynomus.license'

license {
    header = file('../Apache2License.txt')
    strictCheck true
}

// ...
```

My first attempt at applying the license plugin to all non-root projects looked as follows:

Modified root `build.gradle`:

``` groovy
buildscript {
    repositories {
        jcenter()

        maven {
            url "https://plugins.gradle.org/m2/"
        }
    }

    dependencies {
        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
    }
}

allprojects {
    repositories {
        jcenter()
    }

    apply plugin: 'com.github.hierynomus.license'

    license {
        header = file('../Apache2License.txt')
        strictCheck true
    }

}

// ...
```

Modified bugshaker `build.gradle`:

``` groovy
buildscript {
    dependencies {
        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
        // ...
    }
}

apply plugin: 'com.android.library'
apply plugin: 'com.jfrog.bintray'
// ...
```

When I tried to sync using Android Studio, this produced the following error message:

```
Error:Could not find com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5.
Searched in the following locations:
    file:/Applications/Android Studio Canary.app/Contents/gradle/m2repository/com/jfrog/bintray/gradle/gradle-bintray-plugin/1.5/gradle-bintray-plugin-1.5.pom
    file:/Applications/Android Studio Canary.app/Contents/gradle/m2repository/com/jfrog/bintray/gradle/gradle-bintray-plugin/1.5/gradle-bintray-plugin-1.5.jar
Required by:
    BugShaker:bugshaker:unspecified
```

Trying a `./gradlew clean` was more instructive:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':bugshaker'.
> Could not resolve all dependencies for configuration ':bugshaker:classpath'.
   > Cannot resolve external dependency com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5 because no repositories are defined.
     Required by:
         BugShaker:bugshaker:unspecified
   > Cannot resolve external dependency com.github.dcendents:android-maven-gradle-plugin:1.3 because no repositories are defined.
     Required by:
         BugShaker:bugshaker:unspecified
   > Cannot resolve external dependency com.noveogroup.android:check:1.2.3 because no repositories are defined.
     Required by:
         BugShaker:bugshaker:unspecified
   > Cannot resolve external dependency com.btkelly:gnag:0.1.0 because no repositories are defined.
     Required by:
         BugShaker:bugshaker:unspecified
```

**because no repositories are defined** is the key part here. My assumption had been that the `jcenter()` method call in the root project's `buildscript { repositories { ... } }` closure was in some way 'inherited', and that all projects had access to jCenter in the buildscript closures as a result. I believe that this is in fact at least partly false.

_It must be at least partly false_ because of the Gradle errors shown above; the modified bugshaker build.gradle file defined it's own `buildscript` configuration with _no_ external repositories included, and this meant that Gradle could not locate any of the third-party dependencies defined in there.

_It might be partly true_ because the `build.gradle` file in the example subproject applies the `com.android.application` plugin without defining any buildscript repositories. However, adding an empty `buildscript` block (to try to "break" any "inheritance" that might be going on) doesn't break anything, so maybe this supposition is false and the android plugins are treated specially? This idea is consistent with the earliest error message seen above, in which a (local-to-Android-Studio) maven repository was searched for third-party dependencies. Ah ha, here we go:

<img width="614" alt="screen shot 2016-01-14 at 5 56 41 pm" src="https://cloud.githubusercontent.com/assets/6463980/12340331/406f52b4-bae8-11e5-823d-0e4e6b87dc3c.png">

So this suggests that my supposition was completely false; i.e., there is no "inheritance" of buildscript configuration from a root project.
