### PR TITLE
Add 'bugshaker' string to provider authority

### DIFF
--- a/bugshaker/src/main/AndroidManifest.xml
+++ b/bugshaker/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application>
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
+            android:authorities="${applicationId}.bugshaker.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/ScreenshotProvider.java
@@ -33,7 +33,7 @@ import java.io.OutputStream;
 
 final class ScreenshotProvider {
 
-    private static final String AUTHORITY_SUFFIX = ".fileprovider";
+    private static final String AUTHORITY_SUFFIX = ".bugshaker.fileprovider";
     private static final String SCREENSHOTS_DIRECTORY_NAME = "bug-reports";
     private static final String SCREENSHOT_FILE_NAME = "latest-screenshot.jpg";
     private static final int JPEG_COMPRESSION_QUALITY = 90;


### PR DESCRIPTION
This vastly reduces the probability of conflict with a provider authority defined by the embedding application.
