### PR TITLE
Centralize method used to add attachment Uris

### DIFF
--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/EnvironmentCapabilitiesProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/EnvironmentCapabilitiesProvider.java
@@ -28,6 +28,11 @@ import java.util.List;
 
 final class EnvironmentCapabilitiesProvider {
 
+    private static final String[] DUMMY_EMAIL_ADDRESSES = new String[] {"someone@example.com"};
+    private static final String DUMMY_EMAIL_SUBJECT_LINE = "Any Subject Line";
+    private static final String DUMMY_EMAIL_BODY = "Any Body";
+    private static final Uri DUMMY_EMAIL_URI = Uri.EMPTY;
+
     @NonNull
     private final PackageManager packageManager;
 
@@ -72,23 +77,20 @@ final class EnvironmentCapabilitiesProvider {
 
     @NonNull
     private List<ResolveInfo> getEmailAppList() {
+        final Intent queryIntent = genericEmailIntentProvider.getEmailIntent(
+                DUMMY_EMAIL_ADDRESSES, DUMMY_EMAIL_SUBJECT_LINE, DUMMY_EMAIL_BODY);
+
         return packageManager.queryIntentActivities(
-                getBasicPlaceholderEmailIntent(), PackageManager.MATCH_DEFAULT_ONLY);
+                queryIntent, PackageManager.MATCH_DEFAULT_ONLY);
     }
 
     @NonNull
     private List<ResolveInfo> getEmailWithAttachmentAppList() {
-        final Intent placeholderIntent = getBasicPlaceholderEmailIntent();
-        placeholderIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, new ArrayList<Uri>());
+        final Intent queryIntent = genericEmailIntentProvider.getEmailWithAttachmentIntent(
+                DUMMY_EMAIL_ADDRESSES, DUMMY_EMAIL_SUBJECT_LINE, DUMMY_EMAIL_BODY, DUMMY_EMAIL_URI);
 
         return packageManager.queryIntentActivities(
-                placeholderIntent, PackageManager.MATCH_DEFAULT_ONLY);
-    }
-
-    @NonNull
-    private Intent getBasicPlaceholderEmailIntent() {
-        return genericEmailIntentProvider.getBasicEmailIntent(
-                new String[] {"someone@example.com"}, "Any Subject", "Any Body");
+                queryIntent, PackageManager.MATCH_DEFAULT_ONLY);
     }
 
     private void logEmailAppNames(

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/FeedbackEmailIntentProvider.java
@@ -50,7 +50,10 @@ final class FeedbackEmailIntentProvider {
             @NonNull final String[] emailAddresses,
             @NonNull final String emailSubjectLine) {
 
-        return getBaseFeedbackEmailIntent(emailAddresses, emailSubjectLine);
+        final String appInfo = getApplicationInfoString();
+
+        return genericEmailIntentProvider.getEmailIntent(
+                emailAddresses, emailSubjectLine, appInfo);
     }
 
     @NonNull
@@ -59,22 +62,10 @@ final class FeedbackEmailIntentProvider {
             @NonNull final String emailSubjectLine,
             @NonNull final Uri screenshotUri) {
 
-        final Intent emailIntent = getBaseFeedbackEmailIntent(emailAddresses, emailSubjectLine);
-
-        emailIntent.putExtra(Intent.EXTRA_STREAM, screenshotUri);
-
-        return emailIntent;
-    }
-
-    @NonNull
-    Intent getBaseFeedbackEmailIntent(
-            @NonNull final String[] emailAddresses,
-            @NonNull final String emailSubjectLine) {
-
         final String appInfo = getApplicationInfoString();
 
-        return genericEmailIntentProvider
-                .getBasicEmailIntent(emailAddresses, emailSubjectLine, appInfo);
+        return genericEmailIntentProvider.getEmailWithAttachmentIntent(
+                emailAddresses, emailSubjectLine, appInfo, screenshotUri);
     }
 
     @NonNull

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/GenericEmailIntentProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/GenericEmailIntentProvider.java
@@ -23,7 +23,7 @@ import android.support.annotation.NonNull;
 final class GenericEmailIntentProvider {
 
     @NonNull
-    Intent getBasicEmailIntent(
+    Intent getEmailIntent(
             @NonNull final String[] emailAddresses,
             @NonNull final String emailSubjectLine,
             @NonNull final String emailBody) {
@@ -33,6 +33,20 @@ final class GenericEmailIntentProvider {
         result.putExtra(Intent.EXTRA_EMAIL, emailAddresses);
         result.putExtra(Intent.EXTRA_SUBJECT, emailSubjectLine);
         result.putExtra(Intent.EXTRA_TEXT, emailBody);
+        return result;
+    }
+
+    @NonNull
+    Intent getEmailWithAttachmentIntent(
+        @NonNull final String[] emailAddresses,
+        @NonNull final String emailSubjectLine,
+        @NonNull final String emailBody,
+        @NonNull final Uri attachmentUri) {
+
+        final Intent result = getEmailIntent(emailAddresses, emailSubjectLine, emailBody);
+
+        result.putExtra(Intent.EXTRA_STREAM, attachmentUri);
+
         return result;
     }
 


### PR DESCRIPTION
While investigating #53, I noticed that the intent used to test whether a device was capable of sending emails with attachments used `Intent.putParcelableArrayListExtra`, whereas the intent sent with _actual_ attachments used `Intent.putExtra`. This commit represents a refactor so that dummy and real intents are both ultimately generated by the same function (and therefore, will always use the same method to attach `Uri` information, be it real or fake).

Note that this change does not resolve #53.
