### PR TITLE
Fix logger not initialized before being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ public class CustomApplication extends Application {
                  .setEmailSubjectLine("Custom Subject Line") // optional
                  .setLoggingEnabled(BuildConfig.DEBUG)       // optional
                  .setIgnoreFlagSecure(true)                  // optional
+                 .assemble()								 // required
                  .start();                                   // required
     }
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public class CustomApplication extends Application {
                  .setEmailSubjectLine("Custom Subject Line") // optional
                  .setLoggingEnabled(BuildConfig.DEBUG)       // optional
                  .setIgnoreFlagSecure(true)                  // optional
-                 .assemble()								 // required
+                 .assemble()                                 // required
                  .start();                                   // required
     }
 

--- a/bugshaker/config/pmd.xml
+++ b/bugshaker/config/pmd.xml
@@ -78,6 +78,7 @@
 
     <rule ref="rulesets/java/logging-java.xml">
         <exclude name="GuardLogStatementJavaUtil" />
+        <exclude name="LoggerIsNotStaticFinal" />
     </rule>
 
     <rule ref="rulesets/java/migrating.xml" />

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/BugShaker.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/BugShaker.java
@@ -102,7 +102,7 @@ public final class BugShaker implements ShakeDetector.Listener {
      */
     public BugShaker setEmailAddresses(@NonNull final String... emailAddresses) {
         if (assembled || startAttempted) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Configuration must be complete before calling assemble or start");
         }
 
@@ -120,7 +120,7 @@ public final class BugShaker implements ShakeDetector.Listener {
      */
     public BugShaker setEmailSubjectLine(@NonNull final String emailSubjectLine) {
         if (assembled || startAttempted) {
-            throw new RuntimeException(RECONFIGURATION_EXCEPTION_MESSAGE);
+            throw new IllegalStateException(RECONFIGURATION_EXCEPTION_MESSAGE);
         }
 
         this.emailSubjectLine = emailSubjectLine;
@@ -136,7 +136,7 @@ public final class BugShaker implements ShakeDetector.Listener {
      */
     public BugShaker setLoggingEnabled(final boolean loggingEnabled) {
         if (assembled || startAttempted) {
-            throw new RuntimeException(RECONFIGURATION_EXCEPTION_MESSAGE);
+            throw new IllegalStateException(RECONFIGURATION_EXCEPTION_MESSAGE);
         }
 
         this.loggingEnabled = loggingEnabled;
@@ -155,7 +155,7 @@ public final class BugShaker implements ShakeDetector.Listener {
      */
     public BugShaker setIgnoreFlagSecure(final boolean ignoreFlagSecure) {
         if (assembled || startAttempted) {
-            throw new RuntimeException(RECONFIGURATION_EXCEPTION_MESSAGE);
+            throw new IllegalStateException(RECONFIGURATION_EXCEPTION_MESSAGE);
         }
 
         this.ignoreFlagSecure = ignoreFlagSecure;
@@ -165,20 +165,20 @@ public final class BugShaker implements ShakeDetector.Listener {
     /**
      * (Required) Assembles dependencies based on provided configuration information. This method
      * CANNOT be called more than once. This method CANNOT be called after calling
-     * code>start</code>.
+     * <code>start</code>.
      *
      * @return the current <code>BugShaker</code> instance (to allow for method chaining)
      */
     public BugShaker assemble() {
         if (assembled) {
-            logger.d("You have already assembled this BugShaker instance. Calling assemble again " +
-                    "is a no-op.");
+            logger.d("You have already assembled this BugShaker instance. Calling assemble again "
+                    + "is a no-op.");
 
             return this;
         }
 
         if (startAttempted) {
-            throw new RuntimeException("You can only call assemble before calling start.");
+            throw new IllegalStateException("You can only call assemble before calling start.");
         }
 
         logger = new Logger(loggingEnabled);
@@ -208,12 +208,12 @@ public final class BugShaker implements ShakeDetector.Listener {
      */
     public void start() {
         if (!assembled) {
-            throw new RuntimeException("You MUST call assemble before calling start.");
+            throw new IllegalStateException("You MUST call assemble before calling start.");
         }
 
         if (startAttempted) {
-            logger.d("You have already attempted to start this BugShaker instance. Calling start " +
-                    "again is a no-op.");
+            logger.d("You have already attempted to start this BugShaker instance. Calling start "
+                    + "again is a no-op.");
 
             return;
         }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/email/EmailCapabilitiesProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/email/EmailCapabilitiesProvider.java
@@ -41,21 +41,26 @@ public final class EmailCapabilitiesProvider {
     @NonNull
     private final GenericEmailIntentProvider genericEmailIntentProvider;
 
+    @NonNull
+    private final Logger logger;
+
     public EmailCapabilitiesProvider(
             @NonNull final PackageManager packageManager,
-            @NonNull final GenericEmailIntentProvider genericEmailIntentProvider) {
+            @NonNull final GenericEmailIntentProvider genericEmailIntentProvider,
+            @NonNull final Logger logger) {
 
         this.packageManager = packageManager;
         this.genericEmailIntentProvider = genericEmailIntentProvider;
+        this.logger = logger;
     }
 
     public boolean canSendEmails() {
-        Logger.d("Checking for email apps...");
+        logger.d("Checking for email apps...");
 
         final List<ResolveInfo> emailAppInfoList = getEmailAppList();
 
         if (emailAppInfoList.isEmpty()) {
-            Logger.d("No email apps found.");
+            logger.d("No email apps found.");
             return false;
         }
 
@@ -64,12 +69,12 @@ public final class EmailCapabilitiesProvider {
     }
 
     boolean canSendEmailsWithAttachments() {
-        Logger.d("Checking for email apps that can send attachments...");
+        logger.d("Checking for email apps that can send attachments...");
 
         final List<ResolveInfo> emailAppInfoList = getEmailWithAttachmentAppList();
 
         if (emailAppInfoList.isEmpty()) {
-            Logger.d("No email apps can send attachments.");
+            logger.d("No email apps can send attachments.");
             return false;
         }
 
@@ -105,7 +110,7 @@ public final class EmailCapabilitiesProvider {
         }
 
         final String emailAppInfoString = TextUtils.join(", ", emailAppNames);
-        Logger.d(prefix + emailAppInfoString);
+        logger.d(prefix + emailAppInfoString);
     }
 
 }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/email/FeedbackEmailFlowManager.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/email/FeedbackEmailFlowManager.java
@@ -63,6 +63,9 @@ public final class FeedbackEmailFlowManager {
     @NonNull
     private final ScreenshotProvider screenshotProvider;
 
+    @NonNull
+    private final Logger logger;
+
     @Nullable
     private AlertDialog bugShakerAlertDialog;
 
@@ -94,9 +97,9 @@ public final class FeedbackEmailFlowManager {
                                 public void onError(final Throwable e) {
                                     final String errorString = "Screenshot capture failed";
                                     toaster.toast(errorString);
-                                    Logger.e(errorString);
+                                    logger.e(errorString);
 
-                                    Logger.printStackTrace(e);
+                                    logger.printStackTrace(e);
 
                                     sendEmailWithoutScreenshot(activity);
                                 }
@@ -113,7 +116,7 @@ public final class FeedbackEmailFlowManager {
                 final String warningString = "Window is secured; no screenshot taken";
 
                 toaster.toast(warningString);
-                Logger.d(warningString);
+                logger.d(warningString);
 
                 sendEmailWithoutScreenshot(activity);
             }
@@ -126,7 +129,8 @@ public final class FeedbackEmailFlowManager {
             @NonNull final Toaster toaster,
             @NonNull final ActivityReferenceManager activityReferenceManager,
             @NonNull final FeedbackEmailIntentProvider feedbackEmailIntentProvider,
-            @NonNull final ScreenshotProvider screenshotProvider) {
+            @NonNull final ScreenshotProvider screenshotProvider,
+            @NonNull final Logger logger) {
 
         this.applicationContext = applicationContext;
         this.emailCapabilitiesProvider = emailCapabilitiesProvider;
@@ -134,6 +138,7 @@ public final class FeedbackEmailFlowManager {
         this.activityReferenceManager = activityReferenceManager;
         this.feedbackEmailIntentProvider = feedbackEmailIntentProvider;
         this.screenshotProvider = screenshotProvider;
+        this.logger = logger;
     }
 
     public void onActivityResumed(@NonNull final Activity activity) {
@@ -151,7 +156,7 @@ public final class FeedbackEmailFlowManager {
             final boolean ignoreFlagSecure) {
 
         if (isFeedbackFlowStarted()) {
-            Logger.d("Feedback flow already started; ignoring shake.");
+            logger.d("Feedback flow already started; ignoring shake.");
             return;
         }
 
@@ -197,12 +202,12 @@ public final class FeedbackEmailFlowManager {
         final boolean result = ignoreFlagSecure || !isWindowSecured;
 
         if (!isWindowSecured) {
-            Logger.d("Window is not secured; should attempt to capture screenshot.");
+            logger.d("Window is not secured; should attempt to capture screenshot.");
         } else {
             if (ignoreFlagSecure) {
-                Logger.d("Window is secured, but we're ignoring that.");
+                logger.d("Window is secured, but we're ignoring that.");
             } else {
-                Logger.d("Window is secured, and we're respecting that.");
+                logger.d("Window is secured, and we're respecting that.");
             }
         }
 
@@ -229,7 +234,7 @@ public final class FeedbackEmailFlowManager {
 
         activity.startActivity(feedbackEmailIntent);
 
-        Logger.d("Sending email with screenshot.");
+        logger.d("Sending email with screenshot.");
     }
 
     private void sendEmailWithoutScreenshot(@NonNull final Activity activity) {
@@ -238,7 +243,7 @@ public final class FeedbackEmailFlowManager {
 
         activity.startActivity(feedbackEmailIntent);
 
-        Logger.d("Sending email with no screenshot.");
+        logger.d("Sending email with no screenshot.");
     }
 
 }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/BaseScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/BaseScreenshotProvider.java
@@ -22,6 +22,8 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import com.github.stkent.bugshaker.utilities.Logger;
+
 import rx.Observable;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
@@ -31,8 +33,15 @@ public abstract class BaseScreenshotProvider implements ScreenshotProvider {
     @NonNull
     private final Context applicationContext;
 
-    public BaseScreenshotProvider(@NonNull final Context applicationContext) {
+    @NonNull
+    private final Logger logger;
+
+    public BaseScreenshotProvider(
+            @NonNull final Context applicationContext,
+            @NonNull final Logger logger) {
+
         this.applicationContext = applicationContext;
+        this.logger = logger;
     }
 
     @NonNull
@@ -46,7 +55,7 @@ public abstract class BaseScreenshotProvider implements ScreenshotProvider {
                 .flatMap(new Func1<Bitmap, Observable<Uri>>() {
                     @Override
                     public Observable<Uri> call(final Bitmap bitmap) {
-                        return ScreenshotUriObservable.create(applicationContext, bitmap);
+                        return ScreenshotUriObservable.create(applicationContext, bitmap, logger);
                     }
                 });
     }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/BasicScreenShotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/BasicScreenShotProvider.java
@@ -21,12 +21,17 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
 
+import com.github.stkent.bugshaker.utilities.Logger;
+
 import rx.Observable;
 
 public final class BasicScreenShotProvider extends BaseScreenshotProvider {
 
-    public BasicScreenShotProvider(@NonNull final Context applicationContext) {
-        super(applicationContext);
+    public BasicScreenShotProvider(
+            @NonNull final Context applicationContext,
+            @NonNull final Logger logger) {
+
+        super(applicationContext, logger);
     }
 
     @NonNull

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/ScreenshotUriObservable.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/ScreenshotUriObservable.java
@@ -35,6 +35,7 @@ import rx.Subscriber;
 
 final class ScreenshotUriObservable {
 
+    @SuppressWarnings("SpellCheckingInspection")
     private static final String AUTHORITY_SUFFIX = ".bugshaker.fileprovider";
     private static final String SCREENSHOTS_DIRECTORY_NAME = "bug-reports";
     private static final String SCREENSHOT_FILE_NAME = "latest-screenshot.jpg";
@@ -42,7 +43,8 @@ final class ScreenshotUriObservable {
 
     static Observable<Uri> create(
             @NonNull final Context applicationContext,
-            @NonNull final Bitmap bitmap) {
+            @NonNull final Bitmap bitmap,
+            @NonNull final Logger logger) {
 
         return Observable.create(new Observable.OnSubscribe<Uri>() {
             @Override
@@ -62,14 +64,14 @@ final class ScreenshotUriObservable {
 
                     fileOutputStream.flush();
 
-                    Logger.d("Screenshot saved to " + screenshotFile.getAbsolutePath());
+                    logger.d("Screenshot saved to " + screenshotFile.getAbsolutePath());
 
                     final Uri result = FileProvider.getUriForFile(
                             applicationContext,
                             applicationContext.getPackageName() + AUTHORITY_SUFFIX,
                             screenshotFile);
 
-                    Logger.d("Screenshot Uri created: " + result);
+                    logger.d("Screenshot Uri created: " + result);
 
                     subscriber.onNext(result);
                     subscriber.onCompleted();
@@ -81,7 +83,7 @@ final class ScreenshotUriObservable {
                             fileOutputStream.close();
                         } catch (final IOException ignored) {
                             // We did our best...
-                            Logger.e("Failed to close OutputStream.");
+                            logger.e("Failed to close OutputStream.");
                         }
                     }
                 }

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/maps/MapScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/email/screenshot/maps/MapScreenshotProvider.java
@@ -29,6 +29,7 @@ import android.view.ViewGroup;
 
 import com.github.stkent.bugshaker.email.screenshot.BaseScreenshotProvider;
 import com.github.stkent.bugshaker.utilities.ActivityUtils;
+import com.github.stkent.bugshaker.utilities.Logger;
 import com.google.android.gms.maps.MapView;
 
 import java.util.ArrayList;
@@ -68,8 +69,11 @@ public final class MapScreenshotProvider extends BaseScreenshotProvider {
         MAP_PAINT.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_ATOP));
     }
 
-    public MapScreenshotProvider(@NonNull final Context applicationContext) {
-        super(applicationContext);
+    public MapScreenshotProvider(
+            @NonNull final Context applicationContext,
+            @NonNull final Logger logger) {
+
+        super(applicationContext, logger);
     }
 
     @NonNull

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/utilities/Logger.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/utilities/Logger.java
@@ -23,7 +23,7 @@ public final class Logger {
 
     private static final String TAG = "BugShaker-Library";
 
-    private boolean loggingEnabled = false;
+    private final boolean loggingEnabled;
 
     public Logger(final boolean loggingEnabled) {
         this.loggingEnabled = loggingEnabled;

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/utilities/Logger.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/utilities/Logger.java
@@ -23,29 +23,25 @@ public final class Logger {
 
     private static final String TAG = "BugShaker-Library";
 
-    private static boolean loggingEnabled = false;
+    private boolean loggingEnabled = false;
 
-    private Logger() {
-
+    public Logger(final boolean loggingEnabled) {
+        this.loggingEnabled = loggingEnabled;
     }
 
-    public static void setLoggingEnabled(final boolean loggingEnabled) {
-        Logger.loggingEnabled = loggingEnabled;
-    }
-
-    public static void d(@NonNull final CharSequence message) {
+    public void d(@NonNull final CharSequence message) {
         if (loggingEnabled) {
             Log.d(TAG, message.toString());
         }
     }
 
-    public static void e(@NonNull final CharSequence message) {
+    public void e(@NonNull final CharSequence message) {
         if (loggingEnabled) {
             Log.e(TAG, message.toString());
         }
     }
 
-    public static void printStackTrace(@NonNull final Throwable throwable) {
+    public void printStackTrace(@NonNull final Throwable throwable) {
         if (loggingEnabled) {
             Log.e(TAG, "Logging caught exception", throwable);
         }

--- a/example/src/main/java/com/example/bugshaker/CustomApplication.java
+++ b/example/src/main/java/com/example/bugshaker/CustomApplication.java
@@ -29,6 +29,7 @@ public final class CustomApplication extends Application {
         BugShaker.get(this)
                  .setEmailAddresses("someone@example.com")
                  .setLoggingEnabled(BuildConfig.DEBUG)
+                 .assemble()
                  .start();
     }
 


### PR DESCRIPTION
This PR fixes #76 by
- altering the scope of the `Logger` utility class (now: one per `BugShaker` instance; prior: global);
- enforcing more rigid sequencing when configuring a `BugShaker` instance.
