### PR TITLE
Search view hierarchy for maps using BFS vs DFS

### DIFF
--- a/bugshaker/build.gradle
+++ b/bugshaker/build.gradle
@@ -64,6 +64,10 @@ android {
     lintOptions {
         abortOnError true
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -79,6 +83,9 @@ dependencies {
 
     compile('com.google.android.gms:play-services-maps:8.4.0') { ext.optional = true }
     compile("com.android.support:appcompat-v7:${supportLibraryVersion}") { ext.optional = true }
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 check {

--- a/bugshaker/config/checkstyle.xml
+++ b/bugshaker/config/checkstyle.xml
@@ -66,7 +66,11 @@
         <module name="LocalFinalVariableName" />
         <module name="LocalVariableName" />
         <module name="MemberName" />
-        <module name="MethodName" />
+
+        <module name="MethodName">
+            <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/>
+        </module>
+
         <module name="PackageName" />
         <module name="ParameterName" />
         <module name="StaticVariableName" />

--- a/bugshaker/config/pmd.xml
+++ b/bugshaker/config/pmd.xml
@@ -68,9 +68,13 @@
 
     <rule ref="rulesets/java/finalizers.xml" />
 
-    <rule ref="rulesets/java/imports.xml" />
+    <rule ref="rulesets/java/imports.xml">
+        <exclude name="TooManyStaticImports" />
+    </rule>
 
-    <rule ref="rulesets/java/junit.xml" />
+    <rule ref="rulesets/java/junit.xml">
+        <exclude name="JUnitTestsShouldIncludeAssert" />
+    </rule>
 
     <rule ref="rulesets/java/logging-jakarta-commons.xml">
         <exclude name="GuardLogStatement" />
@@ -86,6 +90,7 @@
     <rule ref="rulesets/java/naming.xml">
         <exclude name="AbstractNaming" />
         <exclude name="LongVariable" />
+        <exclude name="MethodNamingConventions" />
         <exclude name="ShortClassName" />
         <exclude name="ShortVariable" />
         <exclude name="ShortMethodName" />

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProvider.java
@@ -24,6 +24,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -113,7 +114,8 @@ public final class MapScreenshotProvider extends BaseScreenshotProvider {
     }
 
     @NonNull
-    private List<MapView> locateMapViewsInHierarchy(@NonNull final View view) {
+    @VisibleForTesting
+    protected final List<MapView> locateMapViewsInHierarchy(@NonNull final View view) {
         final List<MapView> result = new ArrayList<>();
 
         final Queue<View> viewsToProcess = new LinkedList<>();

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProvider.java
@@ -33,11 +33,15 @@ import com.github.stkent.bugshaker.utilities.Logger;
 import com.google.android.gms.maps.MapView;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 import rx.Observable;
 import rx.functions.Func1;
 import rx.functions.Func2;
+
+import static android.view.View.VISIBLE;
 
 public final class MapScreenshotProvider extends BaseScreenshotProvider {
 
@@ -112,15 +116,20 @@ public final class MapScreenshotProvider extends BaseScreenshotProvider {
     private List<MapView> locateMapViewsInHierarchy(@NonNull final View view) {
         final List<MapView> result = new ArrayList<>();
 
-        if (view instanceof MapView && view.getVisibility() == View.VISIBLE) {
-            // Yes, MapView is a ViewGroup, but I never want to see anyone nesting a MapView
-            // inside another MapView...
-            result.add((MapView) view);
-        } else if (view instanceof ViewGroup) {
-            final ViewGroup viewGroup = (ViewGroup) view;
+        final Queue<View> viewsToProcess = new LinkedList<>();
+        viewsToProcess.add(view);
 
-            for (int childIndex = 0; childIndex < viewGroup.getChildCount(); childIndex++) {
-                result.addAll(locateMapViewsInHierarchy(viewGroup.getChildAt(childIndex)));
+        while (!viewsToProcess.isEmpty()) {
+            final View viewToProcess = viewsToProcess.remove();
+
+            if (viewToProcess instanceof MapView && viewToProcess.getVisibility() == VISIBLE) {
+                result.add((MapView) viewToProcess);
+            } else if (viewToProcess instanceof ViewGroup) {
+                final ViewGroup viewGroup = (ViewGroup) viewToProcess;
+
+                for (int childIndex = 0; childIndex < viewGroup.getChildCount(); childIndex++) {
+                    viewsToProcess.add(viewGroup.getChildAt(childIndex));
+                }
             }
         }
 

--- a/bugshaker/src/main/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProvider.java
+++ b/bugshaker/src/main/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProvider.java
@@ -115,7 +115,7 @@ public final class MapScreenshotProvider extends BaseScreenshotProvider {
 
     @NonNull
     @VisibleForTesting
-    protected final List<MapView> locateMapViewsInHierarchy(@NonNull final View view) {
+    protected List<MapView> locateMapViewsInHierarchy(@NonNull final View view) {
         final List<MapView> result = new ArrayList<>();
 
         final Queue<View> viewsToProcess = new LinkedList<>();

--- a/bugshaker/src/test/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProviderTest.java
+++ b/bugshaker/src/test/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProviderTest.java
@@ -1,0 +1,43 @@
+package com.github.stkent.bugshaker.flow.email.screenshot.maps;
+
+import android.content.Context;
+import android.view.ViewGroup;
+
+import com.github.stkent.bugshaker.utilities.Logger;
+import com.google.android.gms.maps.MapView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MapScreenshotProviderTest {
+
+    private MapScreenshotProvider mapScreenshotProvider;
+
+    @Mock
+    private Context applicationContext;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        mapScreenshotProvider = new MapScreenshotProvider(applicationContext, new Logger(false));
+    }
+
+    @Test
+    public void testThat_concurrentModificationExceptionIsNotThrown_when_viewHierarchyContainsMultipleMapViews() {
+        final ViewGroup mockRootView = mock(ViewGroup.class);
+        when(mockRootView.getChildCount()).thenReturn(2);
+        when(mockRootView.getChildAt(anyInt())).thenReturn(mock(MapView.class));
+
+        mapScreenshotProvider.locateMapViewsInHierarchy(mockRootView);
+    }
+
+}

--- a/bugshaker/src/test/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProviderTest.java
+++ b/bugshaker/src/test/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProviderTest.java
@@ -17,10 +17,10 @@
 package com.github.stkent.bugshaker.flow.email.screenshot.maps;
 
 import android.content.Context;
+import android.view.View;
 import android.view.ViewGroup;
 
 import com.github.stkent.bugshaker.utilities.Logger;
-import com.google.android.gms.maps.MapView;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -48,11 +48,16 @@ public class MapScreenshotProviderTest {
     }
 
     @Test
-    public void testThat_concurrentModificationExceptionIsNotThrown_when_viewHierarchyContainsMultipleMapViews() {
+    public void testThat_noExceptionThrown_when_searchingViewHierarchyThatContainsMultipleViews() {
+        // Arrange
         final ViewGroup mockRootView = mock(ViewGroup.class);
-        when(mockRootView.getChildCount()).thenReturn(2);
-        when(mockRootView.getChildAt(anyInt())).thenReturn(mock(MapView.class));
+        final int numberOfChildViews = 4;
+        assert numberOfChildViews > 1;
 
+        when(mockRootView.getChildCount()).thenReturn(numberOfChildViews);
+        when(mockRootView.getChildAt(anyInt())).thenReturn(mock(View.class));
+
+        // Act
         mapScreenshotProvider.locateMapViewsInHierarchy(mockRootView);
     }
 

--- a/bugshaker/src/test/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProviderTest.java
+++ b/bugshaker/src/test/java/com/github/stkent/bugshaker/flow/email/screenshot/maps/MapScreenshotProviderTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.bugshaker.flow.email.screenshot.maps;
 
 import android.content.Context;

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
         classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1"
     }
 }


### PR DESCRIPTION
In particular, this is important to ensure that when we combine map
bitmaps with the base non-map bitmap, we respect the layering of the
view hierarchy.

Closes #91 
